### PR TITLE
feat: add simple frontend and improve scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+agent/agent

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# DDMX_DD01
-哇咔咔
+# DDMX_DD01 示例项目
+
+该项目演示一个“Python 管理端 + Go 子服务器”架构的压测系统基础代码，并提供了简易前端页面便于测试接口。
+
+## 目录结构
+
+- `manager/`：FastAPI 编写的管理端服务，负责服务器注册、任务提交与调度。
+- `manager/static/`：内置的极简前端页面。
+- `agent/`：Go 编写的子服务器示例，启动时向管理端注册并提供 `/run_task` 接口。
+- `manager/tests/`：针对管理端接口的单元测试。
+
+## 运行方法
+
+### 管理端
+
+```bash
+pip install fastapi uvicorn pydantic pytest
+uvicorn manager.main:app --reload
+# 浏览器访问 http://localhost:8000/ 使用前端页面
+```
+
+### 子服务器
+
+```bash
+cd agent
+go run .
+```
+
+### 运行测试
+
+```bash
+pytest
+# Go 端编译检查
+go build ./agent
+```
+
+以上代码仅为示例，未真正实现攻击行为，请勿用于非法用途。

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,0 +1,3 @@
+module agent
+
+go 1.20

--- a/agent/main.go
+++ b/agent/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "log"
+    "net/http"
+    "os"
+    "time"
+)
+
+// RegisterReq 定义注册请求结构
+type RegisterReq struct {
+    ServerID       string            `json:"server_id"`
+    Group          []string          `json:"group"`
+    MaxConcurrency map[string]int    `json:"max_concurrency"`
+    IP             string            `json:"ip"`
+    Timestamp      int64             `json:"timestamp"`
+}
+
+// Task 表示一次压测任务
+type Task struct {
+    Targets      []string `json:"targets"`
+    Layer        string   `json:"layer"`
+    Concurrency  int      `json:"concurrency"`
+    Duration     int      `json:"duration"`
+    AttackMethod string   `json:"attack_method"`
+    TaskID       string   `json:"task_id"`
+}
+
+// register 向管理端注册自身能力
+func register(managerURL, serverID string) {
+    req := RegisterReq{
+        ServerID:       serverID,
+        Group:          []string{"L7"},
+        MaxConcurrency: map[string]int{"L7": 100},
+        IP:             "127.0.0.1",
+        Timestamp:      time.Now().Unix(),
+    }
+    data, _ := json.Marshal(req)
+    _, err := http.Post(managerURL+"/api/server/register", "application/json", bytes.NewBuffer(data))
+    if err != nil {
+        log.Println("register error:", err)
+    } else {
+        log.Println("registered to manager")
+    }
+}
+
+func main() {
+    managerURL := os.Getenv("MANAGER_URL")
+    if managerURL == "" {
+        managerURL = "http://localhost:8000"
+    }
+    serverID := os.Getenv("SERVER_ID")
+    if serverID == "" {
+        serverID = "agent-1"
+    }
+
+    register(managerURL, serverID)
+
+    // 处理来自管理端的任务执行请求
+    http.HandleFunc("/run_task", func(w http.ResponseWriter, r *http.Request) {
+        var task Task
+        if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
+            w.WriteHeader(http.StatusBadRequest)
+            return
+        }
+        log.Printf("start task %s: %v\n", task.TaskID, task)
+        // 简单模拟并发执行：为每个并发启动一个 goroutine
+        for i := 0; i < task.Concurrency; i++ {
+            go func(id int) {
+                log.Printf("goroutine %d executing target %s\n", id, task.Targets[0])
+                time.Sleep(time.Duration(task.Duration) * time.Second)
+            }(i)
+        }
+        w.WriteHeader(http.StatusOK)
+    })
+
+    log.Println("agent listening on :8081")
+    log.Fatal(http.ListenAndServe(":8081", nil))
+}

--- a/manager/main.py
+++ b/manager/main.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from .models import (
+    ServerRegisterRequest,
+    TaskSubmitRequest,
+    TaskStatusReport,
+    ServerInfo,
+)
+from .scheduler import Scheduler
+
+app = FastAPI(title="DDOS Pressure Test Manager")
+# 单例调度器，管理所有服务器与任务
+scheduler = Scheduler()
+
+# 挂载静态页面，提供简单的前端界面
+static_dir = Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+
+@app.get("/")
+def index():
+    """返回内置的单页前端页面。"""
+    return FileResponse(static_dir / "index.html")
+
+
+@app.post("/api/server/register")
+def register_server(req: ServerRegisterRequest):
+    """子服务器向管理端注册自身能力。"""
+    server = ServerInfo(
+        server_id=req.server_id,
+        group=req.group,
+        max_concurrency=req.max_concurrency,
+        ip=req.ip,
+        idle_concurrency=req.max_concurrency.copy(),
+    )
+    scheduler.register_server(server)
+    return {"status": "ok"}
+
+
+@app.post("/api/task/submit")
+def submit_task(req: TaskSubmitRequest):
+    """用户提交压测任务。"""
+    task = scheduler.submit_task(req)
+    return {"task_id": task.task_id, "status": task.status, "assigned": task.assigned}
+
+
+@app.post("/api/server/task_status")
+def update_task_status(report: TaskStatusReport):
+    """子服务器汇报任务进度。"""
+    scheduler.update_task_progress(report.task_id, report.progress)
+    return {"status": "ok"}
+
+
+@app.get("/api/task/{task_id}")
+def get_task(task_id: str):
+    """查询任务执行状态。"""
+    task = scheduler.tasks.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="task not found")
+    return {
+        "task_id": task.task_id,
+        "status": task.status,
+        "progress": task.progress,
+        "assigned": task.assigned,
+    }

--- a/manager/models.py
+++ b/manager/models.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from pydantic import BaseModel
+from typing import Dict, List, Optional
+
+
+class ServerRegisterRequest(BaseModel):
+    """子服务器注册时上报的信息。"""
+
+    server_id: str  # 唯一标识
+    group: List[str]  # 服务器所属分组，如 L4/L7
+    max_concurrency: Dict[str, int]  # 各分组最大并发
+    ip: str  # 服务器 IP 地址
+    timestamp: int  # 上报时间戳
+
+
+class TaskSubmitRequest(BaseModel):
+    """用户提交的压测任务参数。"""
+
+    targets: List[str]  # 目标域名或 IP
+    layer: str  # 压测层级 L4/L7
+    concurrency: int  # 并发数
+    duration: int  # 持续时间
+    attack_method: str  # 攻击方法
+
+
+class TaskStatusReport(BaseModel):
+    """子服务器回传任务执行状态。"""
+
+    server_id: str  # 子服务器 ID
+    task_id: str  # 对应任务 ID
+    status: str  # 当前状态
+    progress: int  # 进度百分比
+    logs: Optional[str] = None  # 日志信息
+    timestamp: int  # 上报时间戳
+
+
+class ServerInfo(BaseModel):
+    """管理端记录的服务器信息。"""
+
+    server_id: str  # 唯一标识
+    group: List[str]  # 分组信息
+    max_concurrency: Dict[str, int]  # 最大并发
+    ip: str  # IP 地址
+    idle_concurrency: Dict[str, int]  # 当前空闲并发
+
+
+class Task(BaseModel):
+    """调度器内部表示的任务状态。"""
+
+    task_id: str
+    request: TaskSubmitRequest
+    assigned: Dict[str, int]
+    status: str = "queued"
+    progress: int = 0

--- a/manager/scheduler.py
+++ b/manager/scheduler.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+from typing import Dict, List
+from uuid import uuid4
+
+from .models import TaskSubmitRequest, ServerInfo, Task
+
+
+class Scheduler:
+    """简易调度器，负责服务器注册、任务分配和队列管理"""
+
+    def __init__(self):
+        # 已注册的所有子服务器
+        self.servers: Dict[str, ServerInfo] = {}
+        # 所有任务记录
+        self.tasks: Dict[str, Task] = {}
+        # 因资源不足暂时排队的任务
+        self.queue: List[Task] = []
+
+    # 注册服务器
+    def register_server(self, server: ServerInfo):
+        """登记子服务器的能力信息。"""
+        self.servers[server.server_id] = server
+
+    # 提交任务
+    def submit_task(self, req: TaskSubmitRequest) -> Task:
+        """创建任务对象并尝试立即分配。"""
+        task_id = uuid4().hex
+        task = Task(task_id=task_id, request=req, assigned={})
+        self.tasks[task_id] = task
+        self.dispatch_task(task)
+        return task
+
+    # 按层级分发任务到服务器
+    def dispatch_task(self, task: Task):
+        """根据服务器空闲并发量分配任务。"""
+        layer = task.request.layer
+        needed = task.request.concurrency
+        assigned = 0
+        # 以空闲并发从大到小排序，优先使用资源多的服务器
+        servers = sorted(
+            [s for s in self.servers.values() if layer in s.group],
+            key=lambda s: s.idle_concurrency.get(layer, 0),
+            reverse=True,
+        )
+        for s in servers:
+            idle = s.idle_concurrency.get(layer, 0)
+            if idle <= 0:
+                continue
+            # 每次尽量用尽单台服务器的剩余并发
+            use = min(idle, needed - assigned)
+            if use > 0:
+                s.idle_concurrency[layer] -= use
+                task.assigned[s.server_id] = use
+                assigned += use
+            if assigned >= needed:
+                break
+        # 未分配完则排入队列等待
+        if assigned < needed:
+            task.status = "queued"
+            self.queue.append(task)
+        else:
+            task.status = "assigned"
+
+    # 更新进度并释放资源
+    def update_task_progress(self, task_id: str, progress: int):
+        """更新任务进度，完成后释放并发并尝试调度队列。"""
+        task = self.tasks.get(task_id)
+        if not task:
+            return
+        task.progress = progress
+        if progress >= 100:
+            task.status = "done"
+            # 任务完成后归还已分配的并发资源
+            layer = task.request.layer
+            for server_id, amount in task.assigned.items():
+                server = self.servers.get(server_id)
+                if server:
+                    server.idle_concurrency[layer] = (
+                        server.idle_concurrency.get(layer, 0) + amount
+                    )
+            # 资源释放后尝试调度队列中的任务
+            self.try_dispatch_queue()
+
+    def try_dispatch_queue(self):
+        """释放资源后再次尝试分配队列中的任务。"""
+        for task in list(self.queue):
+            self.queue.remove(task)
+            self.dispatch_task(task)
+

--- a/manager/static/index.html
+++ b/manager/static/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8" />
+    <title>压力测试管理端</title>
+    <style>
+        /* 极简暗色科技风样式 */
+        body {background:#0d1117;color:#e6edf3;font-family:"Courier New",monospace;margin:0;}
+        .container {max-width:600px;margin:auto;padding:40px;}
+        input,select {width:100%;margin:6px 0;padding:8px;background:#161b22;color:#e6edf3;border:1px solid #30363d;}
+        button {padding:8px 16px;background:#238636;color:#fff;border:none;cursor:pointer;margin-top:10px;}
+        button:hover {background:#2ea043;}
+        pre {background:#161b22;padding:10px;overflow:auto;}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2>任务提交</h2>
+    <!-- 输入参数区域 -->
+    <label>目标地址（逗号分隔）</label>
+    <input id="targets" placeholder="a.com,b.com" />
+    <label>层级</label>
+    <select id="layer">
+        <option value="L4">L4</option>
+        <option value="L7" selected>L7</option>
+    </select>
+    <label>并发数</label>
+    <input id="concurrency" type="number" value="50" />
+    <label>持续时间(秒)</label>
+    <input id="duration" type="number" value="60" />
+    <label>攻击方法</label>
+    <input id="method" value="HTTP_Flood" />
+    <button onclick="submitTask()">提交任务</button>
+    <pre id="result"></pre>
+</div>
+<script>
+// 调用管理端 API 提交任务
+async function submitTask(){
+    try {
+        const resp = await fetch('/api/task/submit', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                targets: document.getElementById('targets').value.split(',').map(t=>t.trim()).filter(Boolean),
+                layer: document.getElementById('layer').value,
+                concurrency: parseInt(document.getElementById('concurrency').value),
+                duration: parseInt(document.getElementById('duration').value),
+                attack_method: document.getElementById('method').value
+            })
+        });
+        const data = await resp.json();
+        document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+    } catch (err) {
+        document.getElementById('result').textContent = '请求失败: ' + err;
+    }
+}
+</script>
+</body>
+</html>

--- a/manager/tests/test_api.py
+++ b/manager/tests/test_api.py
@@ -1,0 +1,110 @@
+"""针对管理端 API 的测试用例，确保调度与队列逻辑正确。"""
+
+from fastapi.testclient import TestClient
+from manager.main import app, scheduler
+
+client = TestClient(app)
+
+
+def setup_function():
+    """每个用例执行前清空调度器状态。"""
+    scheduler.servers.clear()
+    scheduler.tasks.clear()
+    scheduler.queue.clear()
+
+
+def register_server():
+    """注册一个只有 L7 能力的测试服务器。"""
+    resp = client.post(
+        "/api/server/register",
+        json={
+            "server_id": "s1",
+            "group": ["L7"],
+            "max_concurrency": {"L7": 100},
+            "ip": "10.0.0.1",
+            "timestamp": 0,
+        },
+    )
+    assert resp.status_code == 200
+
+
+def test_queue_and_release():
+    register_server()
+    assert scheduler.servers["s1"].idle_concurrency["L7"] == 100
+
+    # 提交第一个任务，占用 100 并发中的 50
+    resp = client.post(
+        "/api/task/submit",
+        json={
+            "targets": ["a.com"],
+            "layer": "L7",
+            "concurrency": 50,
+            "duration": 60,
+            "attack_method": "HTTP_Flood",
+        },
+    )
+    first_task = resp.json()
+    assert resp.status_code == 200
+    assert first_task["status"] == "assigned"
+
+    # 第二个任务请求 80 并发，因剩余 50 空闲而进入队列
+    resp = client.post(
+        "/api/task/submit",
+        json={
+            "targets": ["b.com"],
+            "layer": "L7",
+            "concurrency": 80,
+            "duration": 60,
+            "attack_method": "HTTP_Flood",
+        },
+    )
+    second_task = resp.json()
+    assert resp.status_code == 200
+    assert second_task["status"] == "queued"
+    assert scheduler.queue  # 队列中存在任务
+
+    # 第一个任务完成，释放并发，应自动调度队列中的任务
+    client.post(
+        "/api/server/task_status",
+        json={
+            "server_id": "s1",
+            "task_id": first_task["task_id"],
+            "status": "done",
+            "progress": 100,
+            "logs": "",
+            "timestamp": 0,
+        },
+    )
+    queued = scheduler.tasks[second_task["task_id"]]
+    assert queued.status == "assigned"
+    assert not scheduler.queue  # 队列被清空
+
+
+def test_index_page():
+    """首页应返回前端页面内容。"""
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_get_task_detail():
+    """提交任务后可查询其状态，查询不存在任务返回 404。"""
+    register_server()
+    resp = client.post(
+        "/api/task/submit",
+        json={
+            "targets": ["a.com"],
+            "layer": "L7",
+            "concurrency": 10,
+            "duration": 30,
+            "attack_method": "HTTP_Flood",
+        },
+    )
+    task_id = resp.json()["task_id"]
+    resp = client.get(f"/api/task/{task_id}")
+    assert resp.status_code == 200
+    assert resp.json()["task_id"] == task_id
+
+    resp = client.get("/api/task/not-exist")
+    assert resp.status_code == 404
+


### PR DESCRIPTION
## Summary
- 优化静态前端为暗色科技风并加入错误提示
- 为调度器与数据模型补充中文注释并新增任务详情查询测试
- Go 子服务器增加并发执行注释示例

## Testing
- `pip install fastapi uvicorn pydantic pytest` *(失败: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(失败: ModuleNotFoundError: No module named 'fastapi')*
- `cd agent && go build . && echo go-build-success`


------
https://chatgpt.com/codex/tasks/task_e_689440bf776c832b888ed77ef55bbd3c